### PR TITLE
add timeout to topic creation request

### DIFF
--- a/linkstate-edge/kafkanotifier/kafkanotifier.go
+++ b/linkstate-edge/kafkanotifier/kafkanotifier.go
@@ -173,6 +173,7 @@ func ensureTopic(br *sarama.Broker, timeout time.Duration, topicName string) err
 				},
 			},
 		},
+		Timeout: timeout,
 	}
 
 	for {

--- a/topology/kafkanotifier/kafkanotifier.go
+++ b/topology/kafkanotifier/kafkanotifier.go
@@ -239,6 +239,7 @@ func ensureTopic(br *sarama.Broker, timeout time.Duration, topicName string) err
 				},
 			},
 		},
+		Timeout: timeout,
 	}
 
 	for {


### PR DESCRIPTION
I had an issue with immediate topic-creation errors when I switched to a new Kafka version. It turned out the timeout was set to 0 implicitly. I could fix the bug by setting the actual timeout value.

Please review the changes and approve/merge them if they look good to you.

Thanks,
Severin